### PR TITLE
Fix JS scripts

### DIFF
--- a/playwright_stealth/js/chrome.app.js
+++ b/playwright_stealth/js/chrome.app.js
@@ -15,61 +15,60 @@ window.chrome = {
 };
 
 // That means we're running headful and don't need to mock anything
-if ("app" in window.chrome) {
-  return; // Nothing to do here
+if (!("app" in window.chrome)) {
+
+  const makeError = {
+    ErrorInInvocation: (fn) => {
+      const err = new TypeError(`Error in invocation of app.${fn}()`);
+      return utils.stripErrorWithAnchor(err, `at ${fn} (eval at <anonymous>`);
+    },
+  };
+  
+  // There's a some static data in that property which doesn't seem to change,
+  // we should periodically check for updates: `JSON.stringify(window.app, null, 2)`
+  const STATIC_DATA = JSON.parse(
+    `
+    {
+    "isInstalled": false,
+    "InstallState": {
+    "DISABLED": "disabled",
+    "INSTALLED": "installed",
+    "NOT_INSTALLED": "not_installed"
+    },
+    "RunningState": {
+    "CANNOT_RUN": "cannot_run",
+    "READY_TO_RUN": "ready_to_run",
+    "RUNNING": "running"
+    }
+    }
+        `.trim()
+  );
+  
+  window.chrome.app = {
+    ...STATIC_DATA,
+  
+    get isInstalled() {
+      return false;
+    },
+  
+    getDetails: function getDetails() {
+      if (arguments.length) {
+        throw makeError.ErrorInInvocation(`getDetails`);
+      }
+      return null;
+    },
+    getIsInstalled: function getDetails() {
+      if (arguments.length) {
+        throw makeError.ErrorInInvocation(`getIsInstalled`);
+      }
+      return false;
+    },
+    runningState: function getDetails() {
+      if (arguments.length) {
+        throw makeError.ErrorInInvocation(`runningState`);
+      }
+      return "cannot_run";
+    },
+  };
+  utils.patchToStringNested(window.chrome.app);
 }
-
-const makeError = {
-  ErrorInInvocation: (fn) => {
-    const err = new TypeError(`Error in invocation of app.${fn}()`);
-    return utils.stripErrorWithAnchor(err, `at ${fn} (eval at <anonymous>`);
-  },
-};
-
-// There's a some static data in that property which doesn't seem to change,
-// we should periodically check for updates: `JSON.stringify(window.app, null, 2)`
-const STATIC_DATA = JSON.parse(
-  `
-  {
-  "isInstalled": false,
-  "InstallState": {
-  "DISABLED": "disabled",
-  "INSTALLED": "installed",
-  "NOT_INSTALLED": "not_installed"
-  },
-  "RunningState": {
-  "CANNOT_RUN": "cannot_run",
-  "READY_TO_RUN": "ready_to_run",
-  "RUNNING": "running"
-  }
-  }
-      `.trim()
-);
-
-window.chrome.app = {
-  ...STATIC_DATA,
-
-  get isInstalled() {
-    return false;
-  },
-
-  getDetails: function getDetails() {
-    if (arguments.length) {
-      throw makeError.ErrorInInvocation(`getDetails`);
-    }
-    return null;
-  },
-  getIsInstalled: function getDetails() {
-    if (arguments.length) {
-      throw makeError.ErrorInInvocation(`getIsInstalled`);
-    }
-    return false;
-  },
-  runningState: function getDetails() {
-    if (arguments.length) {
-      throw makeError.ErrorInInvocation(`runningState`);
-    }
-    return "cannot_run";
-  },
-};
-utils.patchToStringNested(window.chrome.app);

--- a/playwright_stealth/js/chrome.csi.js
+++ b/playwright_stealth/js/chrome.csi.js
@@ -10,23 +10,17 @@ if (!window.chrome) {
 }
 
 // That means we're running headful and don't need to mock anything
-if ("csi" in window.chrome) {
-  return; // Nothing to do here
+if (!("csi" in window.chrome)) {
+  // Check that the Navigation Timing API v1 is available, we need that
+  if (window.performance && window.performance.timing) {
+    const { timing } = window.performance;
+
+    window.chrome.csi = () => ({
+      onloadT: timing.domContentLoadedEventEnd,
+      startE: timing.navigationStart,
+      pageT: Date.now() - timing.navigationStart,
+      tran: 15, // Transition type or something
+    });
+    utils.patchToString(window.chrome.csi);
+  }
 }
-
-// Check that the Navigation Timing API v1 is available, we need that
-if (!window.performance || !window.performance.timing) {
-  return;
-}
-
-const { timing } = window.performance;
-
-window.chrome.csi = function () {
-  return {
-    onloadT: timing.domContentLoadedEventEnd,
-    startE: timing.navigationStart,
-    pageT: Date.now() - timing.navigationStart,
-    tran: 15, // Transition type or something
-  };
-};
-utils.patchToString(window.chrome.csi);

--- a/playwright_stealth/js/chrome.load.times.js
+++ b/playwright_stealth/js/chrome.load.times.js
@@ -10,111 +10,106 @@ if (!window.chrome) {
 }
 
 // That means we're running headful and don't need to mock anything
-if ("loadTimes" in window.chrome) {
-  return; // Nothing to do here
-}
+if (!("loadTimes" in window.chrome)) {
+
 
 // Check that the Navigation Timing API v1 + v2 is available, we need that
-if (
-  !window.performance ||
-  !window.performance.timing ||
-  !window.PerformancePaintTiming
-) {
-  return;
-}
+if (window.performance && window.performance.timing && window.PerformancePaintTiming) {
 
-const { performance } = window;
-
-// Some stuff is not available on about:blank as it requires a navigation to occur,
-// let's harden the code to not fail then:
-const ntEntryFallback = {
-  nextHopProtocol: "h2",
-  type: "other",
-};
-
-// The API exposes some funky info regarding the connection
-const protocolInfo = {
-  get connectionInfo() {
-    const ntEntry =
-      performance.getEntriesByType("navigation")[0] || ntEntryFallback;
-    return ntEntry.nextHopProtocol;
-  },
-  get npnNegotiatedProtocol() {
-    // NPN is deprecated in favor of ALPN, but this implementation returns the
-    // HTTP/2 or HTTP2+QUIC/39 requests negotiated via ALPN.
-    const ntEntry =
-      performance.getEntriesByType("navigation")[0] || ntEntryFallback;
-    return ["h2", "hq"].includes(ntEntry.nextHopProtocol)
-      ? ntEntry.nextHopProtocol
-      : "unknown";
-  },
-  get navigationType() {
-    const ntEntry =
-      performance.getEntriesByType("navigation")[0] || ntEntryFallback;
-    return ntEntry.type;
-  },
-  get wasAlternateProtocolAvailable() {
-    // The Alternate-Protocol header is deprecated in favor of Alt-Svc
-    // (https://www.mnot.net/blog/2016/03/09/alt-svc), so technically this
-    // should always return false.
-    return false;
-  },
-  get wasFetchedViaSpdy() {
-    // SPDY is deprecated in favor of HTTP/2, but this implementation returns
-    // true for HTTP/2 or HTTP2+QUIC/39 as well.
-    const ntEntry =
-      performance.getEntriesByType("navigation")[0] || ntEntryFallback;
-    return ["h2", "hq"].includes(ntEntry.nextHopProtocol);
-  },
-  get wasNpnNegotiated() {
-    // NPN is deprecated in favor of ALPN, but this implementation returns true
-    // for HTTP/2 or HTTP2+QUIC/39 requests negotiated via ALPN.
-    const ntEntry =
-      performance.getEntriesByType("navigation")[0] || ntEntryFallback;
-    return ["h2", "hq"].includes(ntEntry.nextHopProtocol);
-  },
-};
-
-const { timing } = window.performance;
-
-// Truncate number to specific number of decimals, most of the `loadTimes` stuff has 3
-function toFixed(num, fixed) {
-  var re = new RegExp("^-?\\d+(?:.\\d{0," + (fixed || -1) + "})?");
-  return num.toString().match(re)[0];
-}
-
-const timingInfo = {
-  get firstPaintAfterLoadTime() {
-    // This was never actually implemented and always returns 0.
-    return 0;
-  },
-  get requestTime() {
-    return timing.navigationStart / 1000;
-  },
-  get startLoadTime() {
-    return timing.navigationStart / 1000;
-  },
-  get commitLoadTime() {
-    return timing.responseStart / 1000;
-  },
-  get finishDocumentLoadTime() {
-    return timing.domContentLoadedEventEnd / 1000;
-  },
-  get finishLoadTime() {
-    return timing.loadEventEnd / 1000;
-  },
-  get firstPaintTime() {
-    const fpEntry = performance.getEntriesByType("paint")[0] || {
-      startTime: timing.loadEventEnd / 1000, // Fallback if no navigation occured (`about:blank`)
-    };
-    return toFixed((fpEntry.startTime + performance.timeOrigin) / 1000, 3);
-  },
-};
-
-window.chrome.loadTimes = function () {
-  return {
-    ...protocolInfo,
-    ...timingInfo,
+  const { performance } = window;
+  
+  // Some stuff is not available on about:blank as it requires a navigation to occur,
+  // let's harden the code to not fail then:
+  const ntEntryFallback = {
+    nextHopProtocol: "h2",
+    type: "other",
   };
-};
-utils.patchToString(window.chrome.loadTimes);
+  
+  // The API exposes some funky info regarding the connection
+  const protocolInfo = {
+    get connectionInfo() {
+      const ntEntry =
+        performance.getEntriesByType("navigation")[0] || ntEntryFallback;
+      return ntEntry.nextHopProtocol;
+    },
+    get npnNegotiatedProtocol() {
+      // NPN is deprecated in favor of ALPN, but this implementation returns the
+      // HTTP/2 or HTTP2+QUIC/39 requests negotiated via ALPN.
+      const ntEntry =
+        performance.getEntriesByType("navigation")[0] || ntEntryFallback;
+      return ["h2", "hq"].includes(ntEntry.nextHopProtocol)
+        ? ntEntry.nextHopProtocol
+        : "unknown";
+    },
+    get navigationType() {
+      const ntEntry =
+        performance.getEntriesByType("navigation")[0] || ntEntryFallback;
+      return ntEntry.type;
+    },
+    get wasAlternateProtocolAvailable() {
+      // The Alternate-Protocol header is deprecated in favor of Alt-Svc
+      // (https://www.mnot.net/blog/2016/03/09/alt-svc), so technically this
+      // should always return false.
+      return false;
+    },
+    get wasFetchedViaSpdy() {
+      // SPDY is deprecated in favor of HTTP/2, but this implementation returns
+      // true for HTTP/2 or HTTP2+QUIC/39 as well.
+      const ntEntry =
+        performance.getEntriesByType("navigation")[0] || ntEntryFallback;
+      return ["h2", "hq"].includes(ntEntry.nextHopProtocol);
+    },
+    get wasNpnNegotiated() {
+      // NPN is deprecated in favor of ALPN, but this implementation returns true
+      // for HTTP/2 or HTTP2+QUIC/39 requests negotiated via ALPN.
+      const ntEntry =
+        performance.getEntriesByType("navigation")[0] || ntEntryFallback;
+      return ["h2", "hq"].includes(ntEntry.nextHopProtocol);
+    },
+  };
+  
+  const { timing } = window.performance;
+  
+  // Truncate number to specific number of decimals, most of the `loadTimes` stuff has 3
+  function toFixed(num, fixed) {
+    var re = new RegExp("^-?\\d+(?:.\\d{0," + (fixed || -1) + "})?");
+    return num.toString().match(re)[0];
+  }
+  
+  const timingInfo = {
+    get firstPaintAfterLoadTime() {
+      // This was never actually implemented and always returns 0.
+      return 0;
+    },
+    get requestTime() {
+      return timing.navigationStart / 1000;
+    },
+    get startLoadTime() {
+      return timing.navigationStart / 1000;
+    },
+    get commitLoadTime() {
+      return timing.responseStart / 1000;
+    },
+    get finishDocumentLoadTime() {
+      return timing.domContentLoadedEventEnd / 1000;
+    },
+    get finishLoadTime() {
+      return timing.loadEventEnd / 1000;
+    },
+    get firstPaintTime() {
+      const fpEntry = performance.getEntriesByType("paint")[0] || {
+        startTime: timing.loadEventEnd / 1000, // Fallback if no navigation occured (`about:blank`)
+      };
+      return toFixed((fpEntry.startTime + performance.timeOrigin) / 1000, 3);
+    },
+  };
+  
+  window.chrome.loadTimes = function () {
+    return {
+      ...protocolInfo,
+      ...timingInfo,
+    };
+  };
+  utils.patchToString(window.chrome.loadTimes);
+  }
+}

--- a/playwright_stealth/js/chrome.runtime.js
+++ b/playwright_stealth/js/chrome.runtime.js
@@ -55,199 +55,198 @@ if (!window.chrome) {
 const existsAlready = "runtime" in window.chrome;
 // `chrome.runtime` is only exposed on secure origins
 const isNotSecure = !window.location.protocol.startsWith("https");
-if (existsAlready || (isNotSecure && !opts.runOnInsecureOrigins)) {
-  return; // Nothing to do here
-}
+if (!(existsAlready || (isNotSecure && !opts.runOnInsecureOrigins))) {
 
-window.chrome.runtime = {
-  // There's a bunch of static data in that property which doesn't seem to change,
-  // we should periodically check for updates: `JSON.stringify(window.chrome.runtime, null, 2)`
-  ...STATIC_DATA,
-  // `chrome.runtime.id` is extension related and returns undefined in Chrome
-  get id() {
-    return undefined;
-  },
-  // These two require more sophisticated mocks
-  connect: null,
-  sendMessage: null,
-};
-
-const makeCustomRuntimeErrors = (preamble, method, extensionId) => ({
-  NoMatchingSignature: new TypeError(preamble + `No matching signature.`),
-  MustSpecifyExtensionID: new TypeError(
-    preamble +
-      `${method} called from a webpage must specify an Extension ID (string) for its first argument.`
-  ),
-  InvalidExtensionID: new TypeError(
-    preamble + `Invalid extension id: '${extensionId}'`
-  ),
-});
-
-// Valid Extension IDs are 32 characters in length and use the letter `a` to `p`:
-// https://source.chromium.org/chromium/chromium/src/+/master:components/crx_file/id_util.cc;drc=14a055ccb17e8c8d5d437fe080faba4c6f07beac;l=90
-const isValidExtensionID = (str) =>
-  str.length === 32 && str.toLowerCase().match(/^[a-p]+$/);
-
-/** Mock `chrome.runtime.sendMessage` */
-const sendMessageHandler = {
-  apply: function (target, ctx, args) {
-    const [extensionId, options, responseCallback] = args || [];
-
-    // Define custom errors
-    const errorPreamble = `Error in invocation of runtime.sendMessage(optional string extensionId, any message, optional object options, optional function responseCallback): `;
-    const Errors = makeCustomRuntimeErrors(
-      errorPreamble,
-      `chrome.runtime.sendMessage()`,
-      extensionId
-    );
-
-    // Check if the call signature looks ok
-    const noArguments = args.length === 0;
-    const tooManyArguments = args.length > 4;
-    const incorrectOptions = options && typeof options !== "object";
-    const incorrectResponseCallback =
-      responseCallback && typeof responseCallback !== "function";
-    if (
-      noArguments ||
-      tooManyArguments ||
-      incorrectOptions ||
-      incorrectResponseCallback
-    ) {
-      throw Errors.NoMatchingSignature;
-    }
-
-    // At least 2 arguments are required before we even validate the extension ID
-    if (args.length < 2) {
-      throw Errors.MustSpecifyExtensionID;
-    }
-
-    // Now let's make sure we got a string as extension ID
-    if (typeof extensionId !== "string") {
-      throw Errors.NoMatchingSignature;
-    }
-
-    if (!isValidExtensionID(extensionId)) {
-      throw Errors.InvalidExtensionID;
-    }
-
-    return undefined; // Normal behavior
-  },
-};
-utils.mockWithProxy(
-  window.chrome.runtime,
-  "sendMessage",
-  function sendMessage() {},
-  sendMessageHandler
-);
-
-/**
- * Mock `chrome.runtime.connect`
- *
- * @see https://developer.chrome.com/apps/runtime#method-connect
- */
-const connectHandler = {
-  apply: function (target, ctx, args) {
-    const [extensionId, connectInfo] = args || [];
-
-    // Define custom errors
-    const errorPreamble = `Error in invocation of runtime.connect(optional string extensionId, optional object connectInfo): `;
-    const Errors = makeCustomRuntimeErrors(
-      errorPreamble,
-      `chrome.runtime.connect()`,
-      extensionId
-    );
-
-    // Behavior differs a bit from sendMessage:
-    const noArguments = args.length === 0;
-    const emptyStringArgument = args.length === 1 && extensionId === "";
-    if (noArguments || emptyStringArgument) {
-      throw Errors.MustSpecifyExtensionID;
-    }
-
-    const tooManyArguments = args.length > 2;
-    const incorrectConnectInfoType =
-      connectInfo && typeof connectInfo !== "object";
-
-    if (tooManyArguments || incorrectConnectInfoType) {
-      throw Errors.NoMatchingSignature;
-    }
-
-    const extensionIdIsString = typeof extensionId === "string";
-    if (extensionIdIsString && extensionId === "") {
-      throw Errors.MustSpecifyExtensionID;
-    }
-    if (extensionIdIsString && !isValidExtensionID(extensionId)) {
-      throw Errors.InvalidExtensionID;
-    }
-
-    // There's another edge-case here: extensionId is optional so we might find a connectInfo object as first param, which we need to validate
-    const validateConnectInfo = (ci) => {
-      // More than a first param connectInfo as been provided
-      if (args.length > 1) {
+  window.chrome.runtime = {
+    // There's a bunch of static data in that property which doesn't seem to change,
+    // we should periodically check for updates: `JSON.stringify(window.chrome.runtime, null, 2)`
+    ...STATIC_DATA,
+    // `chrome.runtime.id` is extension related and returns undefined in Chrome
+    get id() {
+      return undefined;
+    },
+    // These two require more sophisticated mocks
+    connect: null,
+    sendMessage: null,
+  };
+  
+  const makeCustomRuntimeErrors = (preamble, method, extensionId) => ({
+    NoMatchingSignature: new TypeError(preamble + `No matching signature.`),
+    MustSpecifyExtensionID: new TypeError(
+      preamble +
+        `${method} called from a webpage must specify an Extension ID (string) for its first argument.`
+    ),
+    InvalidExtensionID: new TypeError(
+      preamble + `Invalid extension id: '${extensionId}'`
+    ),
+  });
+  
+  // Valid Extension IDs are 32 characters in length and use the letter `a` to `p`:
+  // https://source.chromium.org/chromium/chromium/src/+/master:components/crx_file/id_util.cc;drc=14a055ccb17e8c8d5d437fe080faba4c6f07beac;l=90
+  const isValidExtensionID = (str) =>
+    str.length === 32 && str.toLowerCase().match(/^[a-p]+$/);
+  
+  /** Mock `chrome.runtime.sendMessage` */
+  const sendMessageHandler = {
+    apply: function (target, ctx, args) {
+      const [extensionId, options, responseCallback] = args || [];
+  
+      // Define custom errors
+      const errorPreamble = `Error in invocation of runtime.sendMessage(optional string extensionId, any message, optional object options, optional function responseCallback): `;
+      const Errors = makeCustomRuntimeErrors(
+        errorPreamble,
+        `chrome.runtime.sendMessage()`,
+        extensionId
+      );
+  
+      // Check if the call signature looks ok
+      const noArguments = args.length === 0;
+      const tooManyArguments = args.length > 4;
+      const incorrectOptions = options && typeof options !== "object";
+      const incorrectResponseCallback =
+        responseCallback && typeof responseCallback !== "function";
+      if (
+        noArguments ||
+        tooManyArguments ||
+        incorrectOptions ||
+        incorrectResponseCallback
+      ) {
         throw Errors.NoMatchingSignature;
       }
-      // An empty connectInfo has been provided
-      if (Object.keys(ci).length === 0) {
+  
+      // At least 2 arguments are required before we even validate the extension ID
+      if (args.length < 2) {
         throw Errors.MustSpecifyExtensionID;
       }
-      // Loop over all connectInfo props an check them
-      Object.entries(ci).forEach(([k, v]) => {
-        const isExpected = ["name", "includeTlsChannelId"].includes(k);
-        if (!isExpected) {
-          throw new TypeError(errorPreamble + `Unexpected property: '${k}'.`);
-        }
-        const MismatchError = (propName, expected, found) =>
-          TypeError(
-            errorPreamble +
-              `Error at property '${propName}': Invalid type: expected ${expected}, found ${found}.`
-          );
-        if (k === "name" && typeof v !== "string") {
-          throw MismatchError(k, "string", typeof v);
-        }
-        if (k === "includeTlsChannelId" && typeof v !== "boolean") {
-          throw MismatchError(k, "boolean", typeof v);
-        }
-      });
-    };
-    if (typeof extensionId === "object") {
-      validateConnectInfo(extensionId);
-      throw Errors.MustSpecifyExtensionID;
-    }
-
-    // Unfortunately even when the connect fails Chrome will return an object with methods we need to mock as well
-    return utils.patchToStringNested(makeConnectResponse());
-  },
-};
-utils.mockWithProxy(
-  window.chrome.runtime,
-  "connect",
-  function connect() {},
-  connectHandler
-);
-
-function makeConnectResponse() {
-  const onSomething = () => ({
-    addListener: function addListener() {},
-    dispatch: function dispatch() {},
-    hasListener: function hasListener() {},
-    hasListeners: function hasListeners() {
-      return false;
-    },
-    removeListener: function removeListener() {},
-  });
-
-  const response = {
-    name: "",
-    sender: undefined,
-    disconnect: function disconnect() {},
-    onDisconnect: onSomething(),
-    onMessage: onSomething(),
-    postMessage: function postMessage() {
-      if (!arguments.length) {
-        throw new TypeError(`Insufficient number of arguments.`);
+  
+      // Now let's make sure we got a string as extension ID
+      if (typeof extensionId !== "string") {
+        throw Errors.NoMatchingSignature;
       }
-      throw new Error(`Attempting to use a disconnected port object`);
+  
+      if (!isValidExtensionID(extensionId)) {
+        throw Errors.InvalidExtensionID;
+      }
+  
+      return undefined; // Normal behavior
     },
   };
-  return response;
+  utils.mockWithProxy(
+    window.chrome.runtime,
+    "sendMessage",
+    function sendMessage() {},
+    sendMessageHandler
+  );
+  
+  /**
+   * Mock `chrome.runtime.connect`
+   *
+   * @see https://developer.chrome.com/apps/runtime#method-connect
+   */
+  const connectHandler = {
+    apply: function (target, ctx, args) {
+      const [extensionId, connectInfo] = args || [];
+  
+      // Define custom errors
+      const errorPreamble = `Error in invocation of runtime.connect(optional string extensionId, optional object connectInfo): `;
+      const Errors = makeCustomRuntimeErrors(
+        errorPreamble,
+        `chrome.runtime.connect()`,
+        extensionId
+      );
+  
+      // Behavior differs a bit from sendMessage:
+      const noArguments = args.length === 0;
+      const emptyStringArgument = args.length === 1 && extensionId === "";
+      if (noArguments || emptyStringArgument) {
+        throw Errors.MustSpecifyExtensionID;
+      }
+  
+      const tooManyArguments = args.length > 2;
+      const incorrectConnectInfoType =
+        connectInfo && typeof connectInfo !== "object";
+  
+      if (tooManyArguments || incorrectConnectInfoType) {
+        throw Errors.NoMatchingSignature;
+      }
+  
+      const extensionIdIsString = typeof extensionId === "string";
+      if (extensionIdIsString && extensionId === "") {
+        throw Errors.MustSpecifyExtensionID;
+      }
+      if (extensionIdIsString && !isValidExtensionID(extensionId)) {
+        throw Errors.InvalidExtensionID;
+      }
+  
+      // There's another edge-case here: extensionId is optional so we might find a connectInfo object as first param, which we need to validate
+      const validateConnectInfo = (ci) => {
+        // More than a first param connectInfo as been provided
+        if (args.length > 1) {
+          throw Errors.NoMatchingSignature;
+        }
+        // An empty connectInfo has been provided
+        if (Object.keys(ci).length === 0) {
+          throw Errors.MustSpecifyExtensionID;
+        }
+        // Loop over all connectInfo props an check them
+        Object.entries(ci).forEach(([k, v]) => {
+          const isExpected = ["name", "includeTlsChannelId"].includes(k);
+          if (!isExpected) {
+            throw new TypeError(errorPreamble + `Unexpected property: '${k}'.`);
+          }
+          const MismatchError = (propName, expected, found) =>
+            TypeError(
+              errorPreamble +
+                `Error at property '${propName}': Invalid type: expected ${expected}, found ${found}.`
+            );
+          if (k === "name" && typeof v !== "string") {
+            throw MismatchError(k, "string", typeof v);
+          }
+          if (k === "includeTlsChannelId" && typeof v !== "boolean") {
+            throw MismatchError(k, "boolean", typeof v);
+          }
+        });
+      };
+      if (typeof extensionId === "object") {
+        validateConnectInfo(extensionId);
+        throw Errors.MustSpecifyExtensionID;
+      }
+  
+      // Unfortunately even when the connect fails Chrome will return an object with methods we need to mock as well
+      return utils.patchToStringNested(makeConnectResponse());
+    },
+  };
+  utils.mockWithProxy(
+    window.chrome.runtime,
+    "connect",
+    function connect() {},
+    connectHandler
+  );
+  
+  function makeConnectResponse() {
+    const onSomething = () => ({
+      addListener: function addListener() {},
+      dispatch: function dispatch() {},
+      hasListener: function hasListener() {},
+      hasListeners: function hasListeners() {
+        return false;
+      },
+      removeListener: function removeListener() {},
+    });
+  
+    const response = {
+      name: "",
+      sender: undefined,
+      disconnect: function disconnect() {},
+      onDisconnect: onSomething(),
+      onMessage: onSomething(),
+      postMessage: function postMessage() {
+        if (!arguments.length) {
+          throw new TypeError(`Insufficient number of arguments.`);
+        }
+        throw new Error(`Attempting to use a disconnected port object`);
+      },
+    };
+    return response;
+  }
 }

--- a/playwright_stealth/js/generate.magic.arrays.js
+++ b/playwright_stealth/js/generate.magic.arrays.js
@@ -130,8 +130,54 @@ function generateMagicArray(
     },
   });
 
+  const generateFunctionMocks = utils => (
+    proto,
+    itemMainProp,
+    dataArray
+  ) => ({
+    /** Returns the MimeType object with the specified index. */
+    item: utils.createProxy(proto.item, {
+      apply(target, ctx, args) {
+        if (!args.length) {
+          throw new TypeError(
+            `Failed to execute 'item' on '${
+              proto[Symbol.toStringTag]
+            }': 1 argument required, but only 0 present.`
+          )
+        }
+        // Special behavior alert:
+        // - Vanilla tries to cast strings to Numbers (only integers!) and use them as property index lookup
+        // - If anything else than an integer (including as string) is provided it will return the first entry
+        const isInteger = args[0] && Number.isInteger(Number(args[0])) // Cast potential string to number first, then check for integer
+        // Note: Vanilla never returns `undefined`
+        return (isInteger ? dataArray[Number(args[0])] : dataArray[0]) || null
+      }
+    }),
+    /** Returns the MimeType object with the specified name. */
+    namedItem: utils.createProxy(proto.namedItem, {
+      apply(target, ctx, args) {
+        if (!args.length) {
+          throw new TypeError(
+            `Failed to execute 'namedItem' on '${
+              proto[Symbol.toStringTag]
+            }': 1 argument required, but only 0 present.`
+          )
+        }
+        return dataArray.find(mt => mt[itemMainProp] === args[0]) || null // Not `undefined`!
+      }
+    }),
+    /** Does nothing and shall return nothing */
+    refresh: proto.refresh
+      ? utils.createProxy(proto.refresh, {
+          apply(target, ctx, args) {
+            return undefined
+          }
+        })
+      : undefined
+  })
+  
   // Generate our functional function mocks :-)
-  const functionMocks = fns.generateFunctionMocks(utils)(
+  const functionMocks = generateFunctionMocks(utils)(
     proto,
     itemMainProp,
     magicArray

--- a/playwright_stealth/js/navigator.plugins.js
+++ b/playwright_stealth/js/navigator.plugins.js
@@ -1,3 +1,4 @@
+
 data = {
   mimeTypes: [
     {
@@ -47,19 +48,38 @@ data = {
   ],
 };
 
-fns = utils.materializeFns(fns);
-
-// That means we're running headful
-const hasPlugins = "plugins" in navigator && navigator.plugins.length;
-if (hasPlugins) {
-  return; // nothing to do here
+const generateMimeTypeArray = mimeTypesData => {
+  return generateMagicArray(
+    mimeTypesData,
+    MimeTypeArray.prototype,
+    MimeType.prototype,
+    'type'
+  )
 }
 
-const mimeTypes = fns.generateMimeTypeArray(utils, fns)(data.mimeTypes);
-const plugins = fns.generatePluginArray(utils, fns)(data.plugins);
+const generatePluginArray = pluginsData => {
+  return generateMagicArray(
+    pluginsData,
+    PluginArray.prototype,
+    Plugin.prototype,
+    'name'
+  )
+}
+
+// That means we're running headful
+let hasPlugins = "plugins" in navigator && navigator.plugins.length;
+hasPlugins = false
+if (!hasPlugins) {
+  
+
+
+
+const mimeTypes = generateMimeTypeArray(data.mimeTypes);
+const plugins = generatePluginArray(data.plugins);
 // Plugin and MimeType cross-reference each other, let's do that now
 // Note: We're looping through `data.plugins` here, not the generated `plugins`
 for (const pluginData of data.plugins) {
+
   pluginData.__mimeTypes.forEach((type, index) => {
     plugins[pluginData.name][index] = mimeTypes[type];
 
@@ -90,3 +110,4 @@ const patchNavigator = (name, value) =>
 
 patchNavigator("mimeTypes", mimeTypes);
 patchNavigator("plugins", plugins);
+}

--- a/playwright_stealth/js/utils.js
+++ b/playwright_stealth/js/utils.js
@@ -165,18 +165,17 @@ utils.replaceProperty = (obj, propName, descriptorOverrides = {}) => {
  * This is evaluated once per execution context (e.g. window)
  */
 utils.preloadCache = () => {
-  if (utils.cache) {
-    return;
+  if (!utils.cache) {
+    utils.cache = {
+      // Used in our proxies
+      Reflect: {
+        get: Reflect.get.bind(Reflect),
+        apply: Reflect.apply.bind(Reflect),
+      },
+      // Used in `makeNativeString`
+      nativeToStringStr: Function.toString + "", // => `function toString() { [native code] }`
+    };
   }
-  utils.cache = {
-    // Used in our proxies
-    Reflect: {
-      get: Reflect.get.bind(Reflect),
-      apply: Reflect.apply.bind(Reflect),
-    },
-    // Used in `makeNativeString`
-    nativeToStringStr: Function.toString + "", // => `function toString() { [native code] }`
-  };
 };
 
 /**
@@ -588,3 +587,5 @@ utils.memoize = (fn) => {
 // Stuff starting below this line is NodeJS specific.
 // --
 // module.exports = utils
+
+utils.init()

--- a/playwright_stealth/js/webgl.vendor.js
+++ b/playwright_stealth/js/webgl.vendor.js
@@ -1,4 +1,3 @@
-console.log(opts);
 const getParameterProxyHandler = {
   apply: function (target, ctx, args) {
     const param = (args || [])[0];

--- a/playwright_stealth/js/window.outerdimensions.js
+++ b/playwright_stealth/js/window.outerdimensions.js
@@ -1,10 +1,9 @@
 "use strict";
 
 try {
-  if (window.outerWidth && window.outerHeight) {
-    return; // nothing to do here
+  if (!(window.outerWidth && window.outerHeight)) {
+    const windowFrame = 85; // probably OS and WM dependent
+    window.outerWidth = window.innerWidth;
+    window.outerHeight = window.innerHeight + windowFrame;
   }
-  const windowFrame = 85; // probably OS and WM dependent
-  window.outerWidth = window.innerWidth;
-  window.outerHeight = window.innerHeight + windowFrame;
 } catch (err) {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tf-playwright-stealth",
-    version="0.0.5",
+    version="0.0.6",
     description="Fork of https://github.com/AtuboDad/playwright_stealth",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Fix JS Scripts
This PR partially replaces PR #7 . This only fixes the js codes that prevents stealth mode from running properly.
## Changes
- Replaces guard return statements that prevents the rest of the code from being executed. (This cause the number of lines changes to be higher than usual) For example:
```javascript
// original 
if ("app" in window.chrome) {
  return; // do nothing
}
// rest of the code

// modified code
if (!("app" in window.chrome)) {
  // rest of the code
}
```
- Fix `timing` declared already errors
- Remove `fns` in `generateMagicArray`
- Add `generateFunctionMocks`
- Remove `fns` in `navigator.plugins.js`
- Add `generateMimeTypeArray` in in `navigator.plugins.js`
- Add `generatePluginArray` in in `navigator.plugins.js`
- Remove `this`, `page`  from `navigator.userAgent.js` as we cannot use Playwright (or Puppeteer) code inside.
- Change how we set the navigator properties  as we cannot use Playwright (or Puppeteer) code inside.


## Notes
- This not change the headers so `HeadlessChrome` is still sent over HTTP headers.
## Screenshots
![example_with_stealth](https://github.com/user-attachments/assets/c0812a4d-2f44-4912-8f7b-c2168cac3a07)
