### PR TITLE
Update typing to work with Python 3.9 and above

### DIFF
--- a/playwright_stealth/core/_stealth_config.py
+++ b/playwright_stealth/core/_stealth_config.py
@@ -75,7 +75,7 @@ class StealthConfig:
     nav_vendor: str = "Google Inc."
     nav_user_agent: str = None
     nav_platform: str = None
-    languages: Tuple[str] = ("en-US", "en")
+    languages: Tuple[str, str] = ("en-US", "en")
     run_on_insecure_origins: Optional[bool] = None
 
     def enabled_scripts(self, properties: Properties):

--- a/playwright_stealth/properties/_header_properties.py
+++ b/playwright_stealth/properties/_header_properties.py
@@ -1,5 +1,5 @@
-import random
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass
@@ -23,7 +23,7 @@ class HeaderProperties:
 
     def __init__(
         self,
-        brands: list[dict],
+        brands: List[dict],
         dnt: str,
         **kwargs,
     ):
@@ -59,7 +59,7 @@ class HeaderProperties:
         else:
             return "Unknown"
 
-    def _generate_sec_ch_ua(self, brands: list[dict]) -> str:
+    def _generate_sec_ch_ua(self, brands: List[dict]) -> str:
         """Generates the Sec_Ch_Ua based brands generated"""
         merged_brands = "".join(
             [f'"{brand["brand"]}";v="{brand["version"]}",' for brand in brands]

--- a/playwright_stealth/properties/_navigator_properties.py
+++ b/playwright_stealth/properties/_navigator_properties.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 
 @dataclass
@@ -18,7 +19,7 @@ class NavigatorProperties:
     brands: list[dict]
     mobile: bool
 
-    def __init__(self, brands: list[dict], dnt: str, **kwargs):
+    def __init__(self, brands: List[dict], dnt: str, **kwargs):
         self.userAgent = kwargs["User-Agent"]
 
         # Shared properties
@@ -53,7 +54,7 @@ class NavigatorProperties:
 
         return "en-US"
 
-    def _generate_languages(self, accept_language: str) -> list[str]:
+    def _generate_languages(self, accept_language: str) -> List[str]:
         """Generates the languages based on the accept language."""
 
         languages_with_quality = accept_language.split(",")

--- a/playwright_stealth/properties/_viewport_properties.py
+++ b/playwright_stealth/properties/_viewport_properties.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Tuple
 import random
 
 
@@ -18,13 +19,13 @@ class ViewportProperties:
         self.outerWidth, self.outerHeight = self._generate_outer_dimensions()
         self.innerWidth, self.innerHeight = self._generate_inner_dimensions()
 
-    def _generate_viewport_dimensions(self) -> tuple[int, int]:
+    def _generate_viewport_dimensions(self) -> Tuple[int, int]:
         return 1920 + random.randint(-100, 100), 1080 + random.randint(-100, 100)
 
-    def _generate_outer_dimensions(self) -> tuple[int, int]:
+    def _generate_outer_dimensions(self) -> Tuple[int, int]:
         return self.width, self.height
 
-    def _generate_inner_dimensions(self) -> tuple[int, int]:
+    def _generate_inner_dimensions(self) -> Tuple[int, int]:
         return (
             self.width - random.randint(0, 20),
             self.height - random.randint(0, 20),

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from typing import Union
 from playwright.async_api import Page as AsyncPage
 from playwright.sync_api import Page as SyncPage
 from playwright_stealth.core._stealth_config import StealthConfig
@@ -16,7 +17,7 @@ def combine_scripts(properties: Properties, config: StealthConfig):
     return "\n".join(scripts)
 
 
-def generate_stealth_headers(properties: Properties, page: AsyncPage | SyncPage):
+def generate_stealth_headers(properties: Properties, page: Union[AsyncPage, SyncPage]):
     """Generates the stealth headers for the page by replacing the original headers with the spoofed ones for every request."""
     page.route(
         "**/*", lambda route: route.continue_(headers=properties.as_dict()["header"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tf-playwright-stealth"
 packages = [
     { include = "playwright_stealth" },
 ]
-version = "1.0.0"
+version = "1.0.1"
 description = "Makes playwright stealthy like a ninja!"
 authors = []
 homepage = "https://www.agentql.com/"

--- a/tests/e2e/configs.py
+++ b/tests/e2e/configs.py
@@ -1,3 +1,4 @@
+from typing import List
 from pydantic import BaseModel
 
 from tests.utils import from_file
@@ -27,7 +28,7 @@ class ScriptConfig(BaseModel):
 
 class MultipleScriptConfig(BaseModel):
     name: str
-    script: list[str]
+    script: List[str]
     query: str
     url: str
 

--- a/tests/e2e/test_multiple_scripts.py
+++ b/tests/e2e/test_multiple_scripts.py
@@ -1,6 +1,7 @@
 import pytest
 import agentql
 import logging
+from typing import List
 from playwright.sync_api import sync_playwright, Page as SyncPage
 from playwright.async_api import async_playwright, Page as AsyncPage
 from .configs import (
@@ -26,7 +27,7 @@ from .configs import (
 log = logging.getLogger(__name__)
 
 
-def extract_query_lines(query_str) -> list[str]:
+def extract_query_lines(query_str) -> List[str]:
     """This function is used to extract the query lines from the query string"""
     lines = query_str.strip().splitlines()
     return [


### PR DESCRIPTION
Currently, this version is not compatible with Python 3.8 (due to use of built-in collection types with square brackets for type annotations like `list[str]`) and Python 3.9 (due to usage of `|`, which is only available since Python 3.10). And it's causing issue for Python SDK as it has dependencies on this library.

This PR adjusts the typing to fix this issue. 