### PR TITLE
Add two remaining items for the fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.0.2
+- Fix compatibility issues with Python 3.8 and above
+
 ## 1.0.1
 - Fix compatibility issues with Python 3.9 and above
 

--- a/playwright_stealth/properties/_navigator_properties.py
+++ b/playwright_stealth/properties/_navigator_properties.py
@@ -9,14 +9,14 @@ class NavigatorProperties:
     userAgent: str
     platform: str
     language: str
-    languages: list[str]
+    languages: List[str]
     appVersion: str
     vendor: str
     deviceMemory: int
     hardwareConcurrency: int
     maxTouchPoints: int
     doNotTrack: str
-    brands: list[dict]
+    brands: List[dict]
     mobile: bool
 
     def __init__(self, brands: List[dict], dnt: str, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tf-playwright-stealth"
 packages = [
     { include = "playwright_stealth" },
 ]
-version = "1.0.1"
+version = "1.0.2"
 description = "Makes playwright stealthy like a ninja!"
 authors = []
 homepage = "https://www.agentql.com/"


### PR DESCRIPTION
Forgot two changes in the previous commit for Python 3.8 compatibility fix. This PR should address it. Tested locally by importing local-built package into Python 3.8 environment SDK. 