### PR TITLE
Allow custom http header configs depending on the browser

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Example",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "./examples/stealth_mode.py",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.testing.pytestArgs": ["tests"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 1.1.0
+- Add ability to have custom headers depending on the browser type. When set, browser-specific headers will be used instead of the default headers.
+```
+await stealth_async(page, config=StealthConfig(browser_type=BrowserType.FIREFOX))
+```
+
 ## 1.0.3
 - Fix when custom headers are not properly applied for async version 
 

--- a/examples/stealth_mode.py
+++ b/examples/stealth_mode.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+import random
+
+from playwright.async_api import Geolocation, ProxySettings, async_playwright
+from playwright_stealth import stealth_async
+from playwright_stealth.core import StealthConfig, BrowserType
+
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
+
+BROWSER_IGNORED_ARGS = [
+    "--enable-automation",
+    "--disable-extensions",
+]
+BROWSER_ARGS = [
+    "--disable-xss-auditor",
+    "--no-sandbox",
+    "--disable-setuid-sandbox",
+    "--disable-blink-features=AutomationControlled",
+    "--disable-features=IsolateOrigins,site-per-process",
+    "--disable-infobars",
+]
+
+
+LOCATIONS = [
+    ("America/New_York", Geolocation(longitude=-74.006, latitude=40.7128)),  # New York, NY
+    ("America/Chicago", Geolocation(longitude=-87.6298, latitude=41.8781)),  # Chicago, IL
+    ("America/Los_Angeles", Geolocation(longitude=-118.2437, latitude=34.0522)),  # Los Angeles, CA
+    ("America/Denver", Geolocation(longitude=-104.9903, latitude=39.7392)),  # Denver, CO
+    ("America/Phoenix", Geolocation(longitude=-112.0740, latitude=33.4484)),  # Phoenix, AZ
+    ("America/Anchorage", Geolocation(longitude=-149.9003, latitude=61.2181)),  # Anchorage, AK
+    ("America/Detroit", Geolocation(longitude=-83.0458, latitude=42.3314)),  # Detroit, MI
+    ("America/Indianapolis", Geolocation(longitude=-86.1581, latitude=39.7684)),  # Indianapolis, IN
+    ("America/Boise", Geolocation(longitude=-116.2023, latitude=43.6150)),  # Boise, ID
+    ("America/Juneau", Geolocation(longitude=-134.4197, latitude=58.3019)),  # Juneau, AK
+]
+
+REFERERS = ["https://www.google.com", "https://www.bing.com", "https://duckduckgo.com"]
+
+ACCEPT_LANGUAGES = ["en-US,en;q=0.9", "en-GB,en;q=0.9", "fr-FR,fr;q=0.9"]
+PROXIES: list[ProxySettings] = [
+    # TODO: replace with your own proxies
+    # {
+    #     "server": "...",
+    #     "username": "...",
+    #     "password": "...",
+    # },
+]
+
+
+async def main():
+    header_dnt = random.choice(["0", "1"])
+    location = random.choice(LOCATIONS)
+    referer = random.choice(REFERERS)
+    accept_language = random.choice(ACCEPT_LANGUAGES)
+    proxy: ProxySettings | None = random.choice(PROXIES) if PROXIES else None
+
+    async with async_playwright() as playwright, await playwright.chromium.launch(
+        headless=False,
+        args=BROWSER_ARGS,
+        ignore_default_args=BROWSER_IGNORED_ARGS,
+    ) as browser:
+        context = await browser.new_context(
+            proxy=proxy,
+            locale="en-US,en,ru",
+            timezone_id=location[0],
+            extra_http_headers={
+                "Accept-Language": accept_language,
+                "Referer": referer,
+                "DNT": header_dnt,
+                "Connection": "keep-alive",
+                "Accept-Encoding": "gzip, deflate, br",
+            },
+            geolocation=location[1],
+            permissions=["notifications"],
+            viewport={
+                "width": 1920 + random.randint(-50, 50),
+                "height": 1080 + random.randint(-50, 50),
+            },
+        )
+
+        page = await context.new_page()
+        await stealth_async(page, config=StealthConfig(browser_type=BrowserType.CHROME))
+
+        # Following URLs are different websites that can be used to test the stealth mode
+
+        await page.goto("https://bot.sannysoft.com/")
+
+        await page.wait_for_timeout(30000)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/stealth_mode.py
+++ b/examples/stealth_mode.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 
-from playwright.async_api import Geolocation, ProxySettings, async_playwright
+from playwright.async_api import ProxySettings, async_playwright
 from playwright_stealth import stealth_async
 from playwright_stealth.core import StealthConfig, BrowserType
 
@@ -10,36 +10,6 @@ from playwright_stealth.core import StealthConfig, BrowserType
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
-BROWSER_IGNORED_ARGS = [
-    "--enable-automation",
-    "--disable-extensions",
-]
-BROWSER_ARGS = [
-    "--disable-xss-auditor",
-    "--no-sandbox",
-    "--disable-setuid-sandbox",
-    "--disable-blink-features=AutomationControlled",
-    "--disable-features=IsolateOrigins,site-per-process",
-    "--disable-infobars",
-]
-
-
-LOCATIONS = [
-    ("America/New_York", Geolocation(longitude=-74.006, latitude=40.7128)),  # New York, NY
-    ("America/Chicago", Geolocation(longitude=-87.6298, latitude=41.8781)),  # Chicago, IL
-    ("America/Los_Angeles", Geolocation(longitude=-118.2437, latitude=34.0522)),  # Los Angeles, CA
-    ("America/Denver", Geolocation(longitude=-104.9903, latitude=39.7392)),  # Denver, CO
-    ("America/Phoenix", Geolocation(longitude=-112.0740, latitude=33.4484)),  # Phoenix, AZ
-    ("America/Anchorage", Geolocation(longitude=-149.9003, latitude=61.2181)),  # Anchorage, AK
-    ("America/Detroit", Geolocation(longitude=-83.0458, latitude=42.3314)),  # Detroit, MI
-    ("America/Indianapolis", Geolocation(longitude=-86.1581, latitude=39.7684)),  # Indianapolis, IN
-    ("America/Boise", Geolocation(longitude=-116.2023, latitude=43.6150)),  # Boise, ID
-    ("America/Juneau", Geolocation(longitude=-134.4197, latitude=58.3019)),  # Juneau, AK
-]
-
-REFERERS = ["https://www.google.com", "https://www.bing.com", "https://duckduckgo.com"]
-
-ACCEPT_LANGUAGES = ["en-US,en;q=0.9", "en-GB,en;q=0.9", "fr-FR,fr;q=0.9"]
 PROXIES: list[ProxySettings] = [
     # TODO: replace with your own proxies
     # {
@@ -51,40 +21,14 @@ PROXIES: list[ProxySettings] = [
 
 
 async def main():
-    header_dnt = random.choice(["0", "1"])
-    location = random.choice(LOCATIONS)
-    referer = random.choice(REFERERS)
-    accept_language = random.choice(ACCEPT_LANGUAGES)
     proxy: ProxySettings | None = random.choice(PROXIES) if PROXIES else None
 
     async with async_playwright() as playwright, await playwright.chromium.launch(
         headless=False,
-        args=BROWSER_ARGS,
-        ignore_default_args=BROWSER_IGNORED_ARGS,
     ) as browser:
-        context = await browser.new_context(
-            proxy=proxy,
-            locale="en-US,en,ru",
-            timezone_id=location[0],
-            extra_http_headers={
-                "Accept-Language": accept_language,
-                "Referer": referer,
-                "DNT": header_dnt,
-                "Connection": "keep-alive",
-                "Accept-Encoding": "gzip, deflate, br",
-            },
-            geolocation=location[1],
-            permissions=["notifications"],
-            viewport={
-                "width": 1920 + random.randint(-50, 50),
-                "height": 1080 + random.randint(-50, 50),
-            },
-        )
-
+        context = await browser.new_context(proxy=proxy)
         page = await context.new_page()
         await stealth_async(page, config=StealthConfig(browser_type=BrowserType.CHROME))
-
-        # Following URLs are different websites that can be used to test the stealth mode
 
         await page.goto("https://bot.sannysoft.com/")
 

--- a/playwright_stealth/core/__init__.py
+++ b/playwright_stealth/core/__init__.py
@@ -1,3 +1,3 @@
-from ._stealth_config import StealthConfig
+from ._stealth_config import StealthConfig, BrowserType
 
-__ALL__ = ["StealthConfig"]
+__ALL__ = ["StealthConfig", "BrowserType"]

--- a/playwright_stealth/core/_stealth_config.py
+++ b/playwright_stealth/core/_stealth_config.py
@@ -2,7 +2,7 @@ import json
 from dataclasses import dataclass
 from typing import Dict, Tuple, Optional
 import os
-from playwright_stealth.properties import Properties
+from playwright_stealth.properties import Properties, BrowserType
 
 
 def from_file(name) -> str:
@@ -68,6 +68,7 @@ class StealthConfig:
     navigator_user_agent: bool = True
     navigator_vendor: bool = True
     outerdimensions: bool = True
+    browser_type: BrowserType = BrowserType.CHROME
 
     # options
     vendor: str = "Intel Inc."

--- a/playwright_stealth/properties/__init__.py
+++ b/playwright_stealth/properties/__init__.py
@@ -1,3 +1,3 @@
-from ._properties import Properties
+from ._properties import Properties, BrowserType
 
-__ALL__ = ["Properties"]
+__ALL__ = ["Properties", "BrowserType"]

--- a/playwright_stealth/properties/_header_properties.py
+++ b/playwright_stealth/properties/_header_properties.py
@@ -25,6 +25,7 @@ class HeaderProperties:
         self,
         brands: List[dict],
         dnt: str,
+        client_hint_headers_enabled: True,
         **kwargs,
     ):
         # Passed by library
@@ -38,10 +39,11 @@ class HeaderProperties:
         self.dnt = dnt
 
         # # Self generated headers
-        self.sec_ch_ua = self._generate_sec_ch_ua(brands)
-        self.sec_ch_ua_mobile = self._generate_sec_ch_ua_mobile()
-        self.sec_ch_ua_platform = self._generate_sec_ch_ua_platform()
-        self.sec_ch_ua_form_factors = self._generate_sec_ch_ua_form_factors()
+        if client_hint_headers_enabled:
+            self.sec_ch_ua = self._generate_sec_ch_ua(brands)
+            self.sec_ch_ua_mobile = self._generate_sec_ch_ua_mobile()
+            self.sec_ch_ua_platform = self._generate_sec_ch_ua_platform()
+            self.sec_ch_ua_form_factors = self._generate_sec_ch_ua_form_factors()
 
     def _generate_sec_ch_ua_platform(self) -> str:
         """Generates the Sec_Ch_Ua_Platform based on the user agent platform."""

--- a/playwright_stealth/properties/_header_properties.py
+++ b/playwright_stealth/properties/_header_properties.py
@@ -25,7 +25,7 @@ class HeaderProperties:
         self,
         brands: List[dict],
         dnt: str,
-        client_hint_headers_enabled: True,
+        client_hint_headers_enabled: bool = True,
         **kwargs,
     ):
         # Passed by library

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -2,7 +2,7 @@
 from playwright.async_api import Page as AsyncPage
 from playwright.sync_api import Page as SyncPage
 from playwright_stealth.core import StealthConfig
-from playwright_stealth.properties import Properties
+from playwright_stealth.properties import Properties, BrowserType
 
 
 def combine_scripts(properties: Properties, config: StealthConfig):
@@ -18,12 +18,12 @@ def combine_scripts(properties: Properties, config: StealthConfig):
 
 def generate_stealth_headers_sync(properties: Properties, page: SyncPage):
     """Generates the stealth headers for the page by replacing the original headers with the spoofed ones for every request."""
-    page.route("**/*", lambda route: route.continue_(headers=properties.as_dict()["header"]))
+    page.set_extra_http_headers(properties.as_dict()["header"])
 
 
 async def generate_stealth_headers_async(properties: Properties, page: AsyncPage):
     """Generates the stealth headers for the page by replacing the original headers with the spoofed ones for every request."""
-    await page.route("**/*", lambda route: route.continue_(headers=properties.as_dict()["header"]))
+    await page.set_extra_http_headers(properties.as_dict()["header"])
 
 
 def stealth_sync(page: SyncPage, config: StealthConfig = None):
@@ -37,7 +37,7 @@ def stealth_sync(page: SyncPage, config: StealthConfig = None):
 
 async def stealth_async(page: AsyncPage, config: StealthConfig = None):
     """teaches asynchronous playwright Page to be stealthy like a ninja!"""
-    properties = Properties()
+    properties = Properties(browser_type=config.browser_type if config else BrowserType.CHROME)
     combined_script = combine_scripts(properties, config)
     await generate_stealth_headers_async(properties, page)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "tf-playwright-stealth"
 packages = [{ include = "playwright_stealth" }]
-version = "1.0.3"
+version = "1.1.0"
 description = "Makes playwright stealthy like a ninja!"
 authors = []
 homepage = "https://www.agentql.com/"


### PR DESCRIPTION
Firefox crashes when proxy is in use and chrome headers are specified.
Adding ability to control what kind of headers we want depending on the browser

Looks roughly like this:

```py
async with async_playwright() as playwright, await playwright.firefox.launch(
        headless=False,
    ) as browser:
        context = await browser.new_context( )
        page = await context.new_page()
        await stealth_async(page, config=StealthConfig(browser_type=BrowserType.FIREFOX))
        await page.goto("https://bot.sannysoft.com/")
```