### PR TITLE
fix(security): risk-accept requests CVE-2026-25645 (ENG-13359)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,5 +5,5 @@ reason = "LOW severity (CVSS 3.3). As of 2026-03-26, pygments 2.19.2 is marked l
 
 [[IgnoredVulns]]
 id = "GHSA-gc5v-m9x4-r6x2"
-ignoreUntil = 2026-07-01T00:00:00Z
+ignoreUntil = 2026-07-01
 reason = "CVE-2026-25645 (MEDIUM). requests.utils.extract_zipped_paths() uses a predictable temp path. Advisory explicitly states: 'Standard usage of the Requests library is not affected — only applications that call extract_zipped_paths() directly are impacted.' tf-playwright-stealth does not call this function. Fix requires requests>=2.33.0 which bumps the Python floor to >=3.10, incompatible with our Python >=3.9 support range."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,3 +2,8 @@
 id = "GHSA-5239-wwwm-4pmq"
 ignoreUntil = 2026-06-23
 reason = "LOW severity (CVSS 3.3). As of 2026-03-26, pygments 2.19.2 is marked last_affected in GHSA-5239-wwwm-4pmq with no patched version available. ReDoS in AdlLexer (pygments/lexers/archetype.py) requires attacker-controlled syntax-highlighting input in a local processing path."
+
+[[IgnoredVulns]]
+id = "GHSA-gc5v-m9x4-r6x2"
+ignoreUntil = 2026-07-01T00:00:00Z
+reason = "CVE-2026-25645 (MEDIUM). requests.utils.extract_zipped_paths() uses a predictable temp path. Advisory explicitly states: 'Standard usage of the Requests library is not affected — only applications that call extract_zipped_paths() directly are impacted.' tf-playwright-stealth does not call this function. Fix requires requests>=2.33.0 which bumps the Python floor to >=3.10, incompatible with our Python >=3.9 support range."


### PR DESCRIPTION
## Vulnerability Fixes

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| requests | 2.32.5 | — | CVE-2026-25645 / GHSA-gc5v-m9x4-r6x2 | MEDIUM | ⚠️ Risk accepted — see below |

## Risk acceptance rationale

The advisory explicitly states:

> **Standard usage of the Requests library is not affected by this vulnerability. Only applications that call `extract_zipped_paths()` directly are impacted.**

`tf-playwright-stealth` does not call `requests.utils.extract_zipped_paths()`. The library uses `requests` only as a transitive dependency and never invokes this utility function.

Additionally, the fix (`requests>=2.33.0`) raises the Python floor to `>=3.10`, incompatible with our declared `python = "^3.9"` support range. Python 3.9 reached end-of-life in October 2024, so upgrading the floor is not feasible at this time.

Tracked in `osv-scanner.toml` with `ignoreUntil = 2026-07-01` (within the 3-month MEDIUM SLA).

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| requests | 2.32.5 | — | Risk accepted | No version change — see rationale above |

</details>

Fixes ENG-13359.