### PR TITLE
fix(security): bump urllib3 floor to >=2.7.0 (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -989,14 +989,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -1008,4 +1008,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "97f456aec6bba16f745bc0dd74b1c7d549f08dcedf736af93efa2228826de837"
+content-hash = "d695db78e5870ec10bab1c6dfd570f17d97c5e08fc8c7d1f29b1273cbb7a731b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 python = "^3.10"
 playwright = "^1"
 fake-http-header = "^0.3.5"
-urllib3 = ">=2.5.0"
+urllib3 = ">=2.7.0"
 pygments = ">=2.20.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Vulnerability Fix

| Package | Old | New | Advisory | CVSS |
|---------|-----|-----|----------|------|
| urllib3 | 2.6.3 | 2.7.0 | [GHSA-qccp-gfcp-xxvc](https://osv.dev/GHSA-qccp-gfcp-xxvc) | 8.1 |
| urllib3 | 2.6.3 | 2.7.0 | [GHSA-mf9v-mfxr-j63j](https://osv.dev/GHSA-mf9v-mfxr-j63j) | 6.5 |

### Fix

`urllib3` is a direct dependency in `pyproject.toml`. Floor bumped from `>=2.5.0` to `>=2.7.0`. `poetry.lock` regenerated — urllib3 now resolves to 2.7.0.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| urllib3 | 2.6.3 | 2.7.0 | Patch/security | GHSA-qccp-gfcp-xxvc (SSRF via malformed netloc), GHSA-mf9v-mfxr-j63j (proxy header injection); no API changes |

</details>